### PR TITLE
FEAT: 태그 컬러 ENUM 클래스 수정, 태그 도메인 시간과 날짜 분리

### DIFF
--- a/wantPlant/src/main/java/umc/wantPlant/tag/domain/Tag.java
+++ b/wantPlant/src/main/java/umc/wantPlant/tag/domain/Tag.java
@@ -1,10 +1,13 @@
 package umc.wantPlant.tag.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.wantPlant.tag.domain.dto.request.TagUpdateRequestDto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -14,7 +17,11 @@ public class Tag {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private LocalDateTime startDate;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    @JsonFormat(pattern = "kk:mm")
+    private LocalTime tagTime;
 
     @Enumerated(EnumType.STRING)
     private TagColor tagColor;
@@ -23,11 +30,11 @@ public class Tag {
     private String tagName;
 
     @Builder
-    public Tag(Long id, TagColor tagColor, @NonNull String tagName, LocalDateTime startDate) {
+    public Tag(Long id, LocalDate date, LocalTime tagTime, TagColor tagColor, @NonNull String tagName) {
         this.id = id;
+        this.date = date;
+        this.tagTime = tagTime;
         this.tagColor = tagColor;
         this.tagName = tagName;
-        this.startDate = startDate;
     }
-
 }

--- a/wantPlant/src/main/java/umc/wantPlant/tag/domain/TagColor.java
+++ b/wantPlant/src/main/java/umc/wantPlant/tag/domain/TagColor.java
@@ -1,11 +1,12 @@
 package umc.wantPlant.tag.domain;
 
 public enum TagColor {
-    RED,
-    ORANGE,
-    YELLOW,
-    GREEN,
-    BLUE,
-    INDIGO,
-    VIOLET
+    COLOR_1,
+    COLOR_2,
+    COLOR_3,
+    COLOR_4,
+    COLOR_5,
+    COLOR_6,
+    COLOR_7,
+    COLOR_8,
 }

--- a/wantPlant/src/main/java/umc/wantPlant/tag/domain/dto/request/TagRequestDto.java
+++ b/wantPlant/src/main/java/umc/wantPlant/tag/domain/dto/request/TagRequestDto.java
@@ -1,11 +1,15 @@
 package umc.wantPlant.tag.domain.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 import umc.wantPlant.tag.domain.Tag;
 import umc.wantPlant.tag.domain.TagColor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 
 @Getter
 public class TagRequestDto {
@@ -14,12 +18,18 @@ public class TagRequestDto {
 
     private String tagName;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    private LocalDateTime startDate;
+    @JsonFormat(shape=JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @Schema(example = "12:30")
+    private LocalTime tagTime;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
 
     public Tag toEntity(){
         return Tag.builder()
-                .startDate(startDate)
+                .tagTime(tagTime)
+                .date(date)
                 .tagColor(tagColor)
                 .tagName(tagName)
                 .build();

--- a/wantPlant/src/main/java/umc/wantPlant/tag/domain/dto/request/TagUpdateRequestDto.java
+++ b/wantPlant/src/main/java/umc/wantPlant/tag/domain/dto/request/TagUpdateRequestDto.java
@@ -1,11 +1,14 @@
 package umc.wantPlant.tag.domain.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Getter;
 import org.springframework.format.annotation.DateTimeFormat;
 import umc.wantPlant.tag.domain.Tag;
 import umc.wantPlant.tag.domain.TagColor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 @Getter
 public class TagUpdateRequestDto {
@@ -16,13 +19,19 @@ public class TagUpdateRequestDto {
 
     private String tagName;
 
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
-    private LocalDateTime startDate;
+    @JsonFormat(pattern = "HH:mm")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+    private LocalTime tagTime;
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate date;
 
     public Tag toEntity(){
         return Tag.builder()
                 .id(tagId)
-                .startDate(startDate)
+                .tagTime(tagTime)
+                .date(date)
                 .tagColor(tagColor)
                 .tagName(tagName)
                 .build();

--- a/wantPlant/src/main/java/umc/wantPlant/tag/domain/dto/response/TagResponseDto.java
+++ b/wantPlant/src/main/java/umc/wantPlant/tag/domain/dto/response/TagResponseDto.java
@@ -1,32 +1,34 @@
 package umc.wantPlant.tag.domain.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import umc.wantPlant.tag.domain.Tag;
 import umc.wantPlant.tag.domain.TagColor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Getter
 public class TagResponseDto {
 
     private final Long id;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-    private final LocalDateTime startDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "kk:mm", timezone = "Asia/Seoul")
+    private final LocalTime tagTime;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    private final LocalDate date;
 
     private final TagColor tagColor;
 
     private final String tagName;
 
     @Builder
-    public TagResponseDto(Long id, LocalDateTime startDate, TagColor tagColor, String tagName) {
+    public TagResponseDto(Long id, LocalTime tagTime, LocalDate date, TagColor tagColor, String tagName) {
         this.id = id;
-        this.startDate = startDate;
+        this.tagTime = tagTime;
+        this.date = date;
         this.tagColor = tagColor;
         this.tagName = tagName;
     }
@@ -35,7 +37,8 @@ public class TagResponseDto {
         return TagResponseDto.builder()
                 .id(tag.getId())
                 .tagName(tag.getTagName())
-                .startDate(tag.getStartDate())
+                .tagTime(tag.getTagTime())
+                .date(tag.getDate())
                 .tagColor(tag.getTagColor())
                 .build();
     }

--- a/wantPlant/src/main/java/umc/wantPlant/tag/repository/TagRepository.java
+++ b/wantPlant/src/main/java/umc/wantPlant/tag/repository/TagRepository.java
@@ -13,9 +13,9 @@ public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Optional<Tag> findById(Long id);
 
-    @Query("SELECT t FROM Tag t WHERE YEAR(t.startDate) = :year AND MONTH(t.startDate) = :month")
+    @Query("SELECT t FROM Tag t WHERE YEAR(t.date) = :year AND MONTH(t.date) = :month")
     List<Tag> findTagByMonth(@Param("year") int year, @Param("month") int month);
 
-    @Query("SELECT t FROM Tag t WHERE YEAR(t.startDate) = :year AND MONTH(t.startDate) = :month AND DAY(t.startDate) = :day")
+    @Query("SELECT t FROM Tag t WHERE YEAR(t.date) = :year AND MONTH(t.date) = :month AND DAY(t.date) = :day")
     List<Tag> findTagByDay(@Param("year") int year, @Param("month") int month, @Param("day") int day);
 }

--- a/wantPlant/src/main/java/umc/wantPlant/tag/ui/TagController.java
+++ b/wantPlant/src/main/java/umc/wantPlant/tag/ui/TagController.java
@@ -1,6 +1,7 @@
 package umc.wantPlant.tag.ui;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +25,8 @@ public class TagController {
     @Operation(summary = "태그 생성 API")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),})
-    public ApiResponse<TagResponseDto> addTag(@RequestBody TagRequestDto tagRequestDto){
+    public ApiResponse<TagResponseDto> addTag(
+            @RequestBody TagRequestDto tagRequestDto){
         return ApiResponse.onSuccess(tagService.addTag(tagRequestDto));
     }
 


### PR DESCRIPTION
- [X] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[feat] PR을 등록한다.` 
- [X] 💯 테스트는 잘 통과했나요?
- [X] 🏗️ 빌드는 성공했나요?
- [ ] 🧹 불필요한 코드는 제거했나요?
- [X] 💭 이슈는 등록했나요?
- [X] 🏷️ 라벨은 등록했나요?

## 작업 내용
프론트 요청 사항에 따라
태그 컬러를 기존 색깔별 상수에서 COLOR 1~8 로 명칭 수정
기존 태그의 시간을 LocalDateTime 하나의 변수에서 LocalDate와 LocalTime으로 분리

## 스크린샷

## 주의사항

#12 